### PR TITLE
Assert on failed alloc

### DIFF
--- a/src/backend_carbon.c
+++ b/src/backend_carbon.c
@@ -110,6 +110,7 @@ static void carbon_free(void *ctx)
 void optics_dump_carbon(struct optics_poller *poller, const char *host, const char *port)
 {
     struct carbon *carbon = calloc(1, sizeof(*carbon));
+    optics_assert_alloc(carbon);
     carbon->host = strdup(host);
     carbon->port = strdup(port);
 

--- a/src/backend_prometheus.c
+++ b/src/backend_prometheus.c
@@ -93,6 +93,7 @@ static int64_t dist_count_value(struct prometheus *prometheus, const char *key) 
 static void record(struct prometheus *prometheus, const struct optics_poll *poll)
 {
     struct metric *metric = calloc(1, sizeof(*metric));
+    optics_assert_alloc(metric);
     metric->type = poll->type;
     metric->value = poll->value;
 
@@ -209,6 +210,7 @@ static void prometheus_free(void *ctx)
 void optics_dump_prometheus(struct optics_poller *poller, struct crest *crest)
 {
     struct prometheus *prometheus = calloc(1, sizeof(*prometheus));
+    optics_assert_alloc(prometheus);
 
     crest_add(crest, (struct crest_res) {
                 .path = "/metrics/prometheus",

--- a/src/backend_rest.c
+++ b/src/backend_rest.c
@@ -47,6 +47,7 @@ static struct metrics *metrics_append(struct metrics *metrics, const struct opti
 {
     if (!metrics) {
         metrics = malloc(sizeof(struct metrics) + sizeof(struct metric) * metrics_init_cap);
+        optics_assert_alloc(metrics);
         metrics->len = 0;
         metrics->cap = metrics_init_cap;
     }
@@ -54,6 +55,7 @@ static struct metrics *metrics_append(struct metrics *metrics, const struct opti
     if (metrics->len == metrics->cap) {
         metrics->cap *= 2;
         metrics = realloc(metrics, sizeof(struct metrics) + sizeof(struct metric) * metrics->cap);
+        optics_assert_alloc(metrics);
     }
 
     metrics->data[metrics->len] = (struct metric) {
@@ -212,6 +214,7 @@ static void rest_free(void *ctx)
 void optics_dump_rest(struct optics_poller *poller, struct crest *crest)
 {
     struct rest *rest = calloc(1, sizeof(*rest));
+    optics_assert_alloc(rest);
 
     crest_add(crest, (struct crest_res) {
                 .path = "/metrics/json",

--- a/src/optics.c
+++ b/src/optics.c
@@ -115,6 +115,7 @@ struct optics
 struct optics * optics_create_at(const char *name, optics_ts_t now)
 {
     struct optics *optics = calloc(1, sizeof(*optics));
+    optics_assert_alloc(optics);
 
     if (!region_create(&optics->region, name, sizeof(*optics->header)))
         goto fail_region;
@@ -145,6 +146,7 @@ struct optics * optics_create(const char *name)
 struct optics * optics_open(const char *name)
 {
     struct optics *optics = calloc(1, sizeof(*optics));
+    optics_assert_alloc(optics);
 
     if (!region_open(&optics->region, name)) goto fail_region;
 
@@ -375,6 +377,7 @@ struct optics_lens * optics_lens_get(struct optics *optics, const char *name)
         struct htable_ret ret = htable_get(&optics->keys, name);
         if (ret.ok) {
             lens = calloc(1, sizeof(*lens));
+            optics_assert_alloc(lens);
             lens->optics = optics;
             lens->lens = lens_ptr(optics, ret.value);
         }
@@ -404,6 +407,7 @@ optics_lens_alloc(struct optics *optics, struct lens *lens)
     }
 
     struct optics_lens *ol = calloc(1, sizeof(struct optics_lens));
+    optics_assert_alloc(ol);
     ol->optics = optics;
     ol->lens = lens;
     return ol;
@@ -425,6 +429,7 @@ optics_lens_alloc_get(struct optics *optics, struct lens *lens)
     }
 
     struct optics_lens *ol = calloc(1, sizeof(struct optics_lens));
+    optics_assert_alloc(ol);
     ol->optics = optics;
     ol->lens = lens;
     return ol;

--- a/src/poller.c
+++ b/src/poller.c
@@ -47,7 +47,9 @@ struct optics_poller
 
 struct optics_poller * optics_poller_alloc()
 {
-    return calloc(1, sizeof(struct optics_poller));
+    struct optics_poller *poller = calloc(1, sizeof(*poller));
+    optics_assert_alloc(poller);
+    return poller;
 }
 
 void optics_poller_free(struct optics_poller *poller)

--- a/src/poller_poll.c
+++ b/src/poller_poll.c
@@ -100,6 +100,8 @@ static void poller_poll_optics(
         struct optics_poller *poller, struct poller_list_item *item, optics_ts_t ts)
 {
     struct optics_key *key = calloc(1, sizeof(*key));
+    optics_assert_alloc(key);
+
     optics_key_push(key, optics_get_prefix(item->optics));
 
     struct poller_poll_ctx ctx = {

--- a/src/poller_thread.c
+++ b/src/poller_thread.c
@@ -51,6 +51,7 @@ struct optics_thread * optics_thread_start(struct optics_poller *poller, optics_
     }
 
     struct optics_thread *thread = calloc(1, sizeof(*thread));
+    optics_assert_alloc(thread);
     thread->poller = poller;
     thread->freq = freq;
 

--- a/src/region.c
+++ b/src/region.c
@@ -262,6 +262,7 @@ static optics_off_t region_grow(struct region *region, size_t len)
     // region_ptr.
 
     struct region_vma *old = malloc(sizeof(*old));
+    optics_assert_alloc(old);
     *old = region->vma;
 
     int prot = PROT_READ | PROT_WRITE;

--- a/src/utils/buffer.c
+++ b/src/utils/buffer.c
@@ -35,6 +35,7 @@ void buffer_reserve(struct buffer *buffer, size_t len)
     buffer->data = buffer->data ?
         realloc(buffer->data, buffer->cap) :
         malloc(buffer->cap);
+    optics_assert_alloc(buffer->data);
 }
 
 void buffer_put(struct buffer *buffer, char c)

--- a/src/utils/crest/crest.c
+++ b/src/utils/crest/crest.c
@@ -55,7 +55,9 @@ struct crest
 
 struct crest *crest_new()
 {
-    return calloc(1, sizeof(struct crest));
+    struct crest *crest = calloc(1, sizeof(struct crest));
+    optics_assert_alloc(crest);
+    return crest;
 }
 
 void crest_free(struct crest *crest)
@@ -92,6 +94,7 @@ bool crest_add(struct crest *crest, struct crest_res raw_res)
     if (crest->started) return false;
 
     struct crest_res *res = malloc(sizeof(*res));
+    optics_assert_alloc(res);
     memcpy(res, &raw_res, sizeof(*res));
 
     struct path *path = path_new(res->path);
@@ -255,6 +258,8 @@ static int microhttpd_cb(
         if (content_length < 0) MHD_NO;
         if (content_length > 0) {
             *args = body = calloc(1, sizeof(*body) + content_length);
+            optics_assert_alloc(body);
+
             body->cap = content_length;
             if (!*data_len) return MHD_YES;
         }

--- a/src/utils/crest/path.c
+++ b/src/utils/crest/path.c
@@ -26,6 +26,7 @@ struct path
 static struct path *path_new(const char *raw)
 {
     struct path *path = calloc(1, sizeof(*path));
+    optics_assert_alloc(path);
 
     enum { max_path_len = 1024 };
     size_t raw_len = strnlen(raw, max_path_len);
@@ -38,7 +39,10 @@ static struct path *path_new(const char *raw)
         path->n++;
     }
 
-    if (path->n) path->items = malloc(path->n * sizeof(path->items[0]));
+    if (path->n) {
+        path->items = malloc(path->n * sizeof(path->items[0]));
+        optics_assert_alloc(path->items);
+    }
 
     size_t j = 0;
     for (size_t i = 0; i < raw_len; ++i) {

--- a/src/utils/crest/router.c
+++ b/src/utils/crest/router.c
@@ -47,8 +47,8 @@ static struct router *router_append(struct router *router, const char *key)
 {
     if (router->len == router->cap) {
         router->cap = router->cap ? router->cap * 2 : 1;
-        router->consts = realloc(
-                router->consts, router->cap * sizeof(router->consts[0]));
+        router->consts = realloc(router->consts, router->cap * sizeof(router->consts[0]));
+        optics_assert_alloc(router->consts);
         memset(router->consts + router->len, 0,
                 (router->cap - router->len) * sizeof(router->consts[0]));
     }
@@ -78,8 +78,10 @@ static bool router_add(
 
     struct path tail = path_tail(path);
     if (path_token_type(head) == token_wildcard) {
-        if (!router->wildcards)
+        if (!router->wildcards) {
             router->wildcards = calloc(1, sizeof(*router->wildcards));
+            optics_assert_alloc(router->wildcards);
+        }
         return router_add(router->wildcards, &tail, res);
     }
 

--- a/src/utils/errors.h
+++ b/src/utils/errors.h
@@ -91,3 +91,6 @@ void optics_vwarn_va(const char *file, int line, const char *fmt, va_list args);
         optics_fail("TODO: " msg);              \
         optics_abort();                         \
     } while (0)
+
+#define optics_assert_alloc(p)                  \
+    optics_assert((p) != NULL, "out-of-memory");

--- a/src/utils/htable.c
+++ b/src/utils/htable.c
@@ -70,6 +70,8 @@ static void htable_resize(struct htable *ht, size_t cap)
     while (new_cap < cap) new_cap *= 2;
 
     struct htable_bucket *new_table = calloc(new_cap, sizeof(*new_table));
+    optics_assert_alloc(new_table);
+
     for (size_t i = 0; i < ht->cap; ++i) {
         struct htable_bucket *bucket = &ht->table[i];
         if (!bucket->key) continue;


### PR DESCRIPTION
Just ensures that if optics runs in an environment where over-commit is disabled that we get early termination in the case where we run out of memory.