### PR TITLE
Prometheus fixes

### DIFF
--- a/src/backend_prometheus.c
+++ b/src/backend_prometheus.c
@@ -90,14 +90,24 @@ static int64_t dist_count_value(struct prometheus *prometheus, const char *key) 
 
 }
 
-// Prometheus considers dots to be some kind of satanic hell spawn which must be
-// extinguished in favour of less threatening and more kid friendly underscores.
+static bool is_valid_char(char c)
+{
+    return
+        (c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= '0' && c <= '9') ||
+        (c == '_' || c == ':');
+}
+
+// Prometheus is very picky about which characters are allowed in a metric
+// name. Until we fix the optics interface to better support both carbon and
+// prometheus, we need to do some ugly character replacement instead.
 static void fix_key(char *dst, const char *src)
 {
     size_t i = 0;
 
     while(src[i] != '\0') {
-        dst[i] = src[i] == '.' ? '_' : src[i];
+        dst[i] = is_valid_char(src[i]) ? src[i] : '_';
         i++;
     }
 

--- a/src/utils/buffer.c
+++ b/src/utils/buffer.c
@@ -64,8 +64,8 @@ void buffer_printf(struct buffer *buffer, const char *fmt, ...)
         va_end(args);
     }
 
-    if (ret > 0 && (size_t) ret > avail) {
-        buffer_reserve(buffer, buffer->len + ret);
+    if (ret > 0 && (size_t) (ret + 1) > avail) { // + 1 -> null byte
+        buffer_reserve(buffer, buffer->len + ret + 1); // + 1 -> null byte
         avail = buffer->cap - buffer->len;
 
         va_list args;

--- a/test/backend_prometheus_test.c
+++ b/test/backend_prometheus_test.c
@@ -17,7 +17,7 @@ optics_test_head(backend_prometheus_basics_test)
     const char *path = "/metrics/prometheus";
 
     struct optics *optics = optics_create(test_name);
-    optics_set_prefix(optics, "optics.tests");
+    optics_set_prefix(optics, "optics.tests-1");
 
     struct optics_lens *counter = optics_counter_alloc(optics, "counter");
     struct optics_lens *gauge = optics_gauge_alloc(optics, "gauge");
@@ -37,17 +37,17 @@ optics_test_head(backend_prometheus_basics_test)
 
         char body[4096];
         snprintf(body, sizeof(body),
-                "# TYPE optics_tests_dist summary\n"
-                "optics_tests_dist{quantile=\"0.5\"} 50\n"
-                "optics_tests_dist{quantile=\"0.9\"} 90\n"
-                "optics_tests_dist{quantile=\"0.99\"} 99\n"
-                "optics_tests_dist_count %lu\n"
-                "# TYPE optics_tests_gauge gauge\n"
-                "optics_tests_gauge 1\n"
-                "# TYPE optics_tests_counter counter\n"
-                "optics_tests_counter %lu\n"
+                "# TYPE optics_tests_1_counter counter\n"
+                "optics_tests_1_counter %lu\n"
+                "# TYPE optics_tests_1_dist summary\n"
+                "optics_tests_1_dist{quantile=\"0.5\"} 50\n"
+                "optics_tests_1_dist{quantile=\"0.9\"} 90\n"
+                "optics_tests_1_dist{quantile=\"0.99\"} 99\n"
+                "optics_tests_1_dist_count %lu\n"
+                "# TYPE optics_tests_1_gauge gauge\n"
+                "optics_tests_1_gauge 1\n"
                 "\n",
-                (it + 1) * 100, (it + 1));
+                (it + 1), (it + 1) * 100);
 
         assert_http_body(port, "GET", path, 200, body);
     }

--- a/test/buffer_test.c
+++ b/test/buffer_test.c
@@ -93,6 +93,38 @@ void printf_test(void **state)
 
 
 // -----------------------------------------------------------------------------
+// printf boundary
+// -----------------------------------------------------------------------------
+
+void printf_boundary_test(void **state)
+{
+    (void) state;
+    struct buffer buffer = {0};
+
+    enum { n = 128 }; // must match buffer_min_cap
+    char data[n + 1] = {0};
+
+    for (size_t i = 0; i < n; ++i) data[i] = 'a';
+    buffer_printf(&buffer, "%s", data);
+
+    for (size_t i = 0; i < n;  ++i) data[i] = 'b';
+    buffer_printf(&buffer, "%s", data);
+
+    for (size_t i = 0; i < n;  ++i) data[i] = 'c';
+    buffer_printf(&buffer, "%s", data);
+
+    for (size_t i = 0; i < n; ++i)
+        assert_true(buffer.data[i] == 'a');
+
+    for (size_t i = 0; i < n; ++i)
+        assert_true(buffer.data[i + n] == 'b');
+
+    for (size_t i = 0; i < n; ++i)
+        assert_true(buffer.data[i + n + n] == 'c');
+}
+
+
+// -----------------------------------------------------------------------------
 // setup
 // -----------------------------------------------------------------------------
 
@@ -102,6 +134,7 @@ int main(void)
         cmocka_unit_test(put_test),
         cmocka_unit_test(write_test),
         cmocka_unit_test(printf_test),
+        cmocka_unit_test(printf_boundary_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Doing a `buffer_printf` which takes up the remaining space of the buffer would cause the last character to be replaced by a `\0` due to `snprintf` always writting a null byte even when there's not enough space for it. The boundary checks were modified to take that extra null char into account.

Properly sanitized the prometheus metric name to only include the allowed characters instead of just replacing `.`. Note that I'll have to revisit the optics interface so that things like hostnames are passed in a special manner so that keys can be constructed more intelligently.