### PR TITLE
Host to source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,8 @@ if(CLANG_TIDY_EXEC)
     message("CLANG-TIDY: ${CLANG_TIDY_EXEC}")
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
     add_custom_target(clang-tidy
-        ${CLANG_TIDY_EXEC} -header-filter='.*' src/*.c src/utils/*.c test/*.c)
+        COMMAND ${CLANG_TIDY_EXEC} -p ${CMAKE_BINARY_DIR} -header-filter='.*' src/*.c src/utils/*.c test/*.c
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 else()
     message("CLANG-TIDY: DISABLED - install clang to enable")
 endif()

--- a/src/backend_rest.c
+++ b/src/backend_rest.c
@@ -61,6 +61,7 @@ static struct metrics *metrics_append(struct metrics *metrics, const struct opti
     struct optics_key key = {0};
     optics_key_push(&key, poll->prefix);
     optics_key_push(&key, poll->host);
+    if (poll->source) optics_key_push(&key, poll->source);
     optics_key_push(&key, poll->key->data);
 
     metrics->data[metrics->len] = (struct metric) {

--- a/src/backend_stdout.c
+++ b/src/backend_stdout.c
@@ -17,7 +17,8 @@ static bool stdout_dump_normalized(
 {
     const struct optics_poll *poll = ctx;
 
-    printf("[%lu] %s.%s.%s: %g\n", ts, poll->prefix, poll->host, key, value);
+    printf("[%lu] %s.%s{host='%s', source='%s'} = %g\n",
+            ts, poll->prefix, key, poll->host, poll->source, value);
 
     return true;
 }

--- a/src/optics.c
+++ b/src/optics.c
@@ -89,7 +89,7 @@ struct optics_packed optics_header
     atomic_off_t lens_head;
 
     char prefix[optics_name_max_len];
-    char host[optics_name_max_len];
+    char source[optics_name_max_len];
 
     struct alloc alloc;
 };
@@ -110,8 +110,6 @@ struct optics
     struct htable keys;
 };
 
-static bool set_default_host(struct optics *optics);
-
 
 // -----------------------------------------------------------------------------
 // open/close
@@ -129,14 +127,12 @@ struct optics * optics_create_at(const char *name, optics_ts_t now)
     if (!optics->header) goto fail_header;
 
     if (!optics_set_prefix(optics, name)) goto fail_prefix;
-    if (!set_default_host(optics)) goto fail_host;
 
     alloc_init(&optics->header->alloc);
     optics->header->epoch_last_inc = now;
 
     return optics;
 
-  fail_host:
   fail_prefix:
   fail_header:
     region_close(&optics->region);
@@ -217,30 +213,25 @@ bool optics_set_prefix(struct optics *optics, const char *prefix)
     return true;
 }
 
-const char *optics_get_host(struct optics *optics)
+
+const char *optics_get_source(struct optics *optics)
 {
-    return optics->header->host;
+    return optics->header->source[0] == '\0' ? NULL : optics->header->source;
 }
 
-bool optics_set_host(struct optics *optics, const char *host)
+bool optics_set_source(struct optics *optics, const char *source)
 {
-    if (strnlen(host, optics_name_max_len) == optics_name_max_len) {
-        optics_fail("host '%s' length is greater than max length '%d'",
-                host, optics_name_max_len);
+    if (strnlen(source, optics_name_max_len) == optics_name_max_len) {
+        optics_fail("source '%s' length is greater than max length '%d'",
+                source, optics_name_max_len);
         return false;
     }
 
-    strlcpy(optics->header->host, host, optics_name_max_len);
+    strlcpy(optics->header->source, source, optics_name_max_len);
     return true;
+
 }
 
-static bool set_default_host(struct optics *optics)
-{
-    char host[optics_name_max_len];
-    if (!hostname(host, sizeof(host))) return false;
-
-    return optics_set_host(optics, host);
-}
 
 // -----------------------------------------------------------------------------
 // alloc

--- a/src/optics.h
+++ b/src/optics.h
@@ -66,8 +66,8 @@ bool optics_unlink_all();
 const char *optics_get_prefix(struct optics *);
 bool optics_set_prefix(struct optics *, const char *prefix);
 
-const char *optics_get_host(struct optics *);
-bool optics_set_host(struct optics *, const char *host);
+const char *optics_get_source(struct optics *);
+bool optics_set_source(struct optics *, const char *source);
 
 
 // -----------------------------------------------------------------------------
@@ -175,6 +175,7 @@ struct optics_poll
 {
     const char *host;
     const char *prefix;
+    const char *source;
     struct optics_key *key;
 
     enum optics_lens_type type;
@@ -218,6 +219,9 @@ bool optics_poller_backend(
         void *ctx,
         optics_backend_cb_t cb,
         optics_backend_free_t free);
+
+bool optics_poller_set_host(struct optics_poller *poller, const char *host);
+const char * optics_poller_get_host(struct optics_poller *poller);
 
 bool optics_poller_poll(struct optics_poller *poller);
 bool optics_poller_poll_at(struct optics_poller *poller, optics_ts_t ts);

--- a/src/opticsd.c
+++ b/src/opticsd.c
@@ -133,6 +133,8 @@ static void print_usage(void)
             "  --dump-prometheus          Enables prometheus HTTP interface\n"
             "  --freq=<n>                 Number of seconds between each polling attempt [10]\n"
             "  --http-port=<port>         Port for HTTP server [3002]\n"
+            "  --hostname=<hostname>      Hostname to include in the key [gethostname()]\n"
+            "  --daemon                   Daemonizes the process\n"
             "  -v --version               Optics verison\n"
             "  -h --help                  Prints this message\n");
 }
@@ -156,6 +158,7 @@ int main(int argc, char **argv)
             {"dump-prometheus", no_argument, 0, 'p'},
             {"freq", required_argument, 0, 'f'},
             {"http-port", required_argument, 0, 'H'},
+            {"hostname", required_argument, 0, 'n'},
             {"daemon", no_argument, 0, 'd'},
             {"version", no_argument, 0, 'v'},
             {"help", no_argument, 0, 'h'},
@@ -194,6 +197,11 @@ int main(int argc, char **argv)
         case 'p':
             backend_selected = true;
             optics_dump_prometheus(poller, crest);
+            break;
+
+        case 'n':
+            if (!optics_poller_set_host(poller, optarg))
+                optics_error_exit();
             break;
 
         case 'd':

--- a/src/poller_poll.c
+++ b/src/poller_poll.c
@@ -33,8 +33,8 @@ struct poller_poll_ctx
     struct optics_poller *poller;
     optics_epoch_t epoch;
 
-    const char *host;
     const char *prefix;
+    const char *source;
     struct optics_key *key;
 
     optics_ts_t ts;
@@ -54,8 +54,9 @@ static enum optics_ret poller_poll_lens(void *ctx_, struct optics_lens *lens)
     size_t old_key = optics_key_push(ctx->key, optics_lens_name(lens));
 
     struct optics_poll poll = {
-        .host = ctx->host,
+        .host = optics_poller_get_host(ctx->poller),
         .prefix = ctx->prefix,
+        .source = ctx->source,
         .key = ctx->key,
         .type = optics_lens_type(lens),
         .ts = ctx->ts,
@@ -109,8 +110,8 @@ static void poller_poll_optics(
     struct poller_poll_ctx ctx = {
         .poller = poller,
         .epoch = item->epoch,
-        .host = optics_get_host(item->optics),
         .prefix = optics_get_prefix(item->optics),
+        .source = optics_get_source(item->optics),
         .key = &key,
         .ts = ts,
     };

--- a/src/utils/socket.c
+++ b/src/utils/socket.c
@@ -43,6 +43,75 @@ int socket_stream_connect(const char *host, const char *port)
     return -1;
 }
 
+int socket_stream_listen(const char *port)
+{
+    struct addrinfo hints = {0};
+    hints.ai_flags = AI_PASSIVE;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *head;
+    int err = getaddrinfo(NULL, port, &hints, &head);
+    if (err) {
+        optics_fail("unable to resolve host '0.0.0.0:%s': %s", port, gai_strerror(err));
+        return -1;
+    }
+
+    int fd = -1;
+    for (struct addrinfo *addr = head; addr; addr = addr->ai_next) {
+
+        fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+        if (fd == -1) continue;
+
+        if (!bind(fd, addr->ai_addr, addr->ai_addrlen)) {
+            if (!listen(fd, 1)) break;
+        }
+
+        close(fd);
+        fd = -1;
+    }
+
+    freeaddrinfo(head);
+
+    if (fd > 0) return fd;
+
+    optics_fail_errno("unable to connect stream socket for host '0.0.0.0:%s'", port);
+    return -1;
+}
+
+int socket_stream_accept(int fd)
+{
+    socklen_t addrlen = 0;
+    struct sockaddr addr = {0};
+
+    int accept_fd = accept4(fd, &addr, &addrlen, 0);
+    if (accept_fd >= 0) return accept_fd;
+
+    optics_fail_errno("unable to accept a socket on fd '%d'", fd);
+    return -1;
+}
+
+
+bool socket_send(int fd, size_t len, const void *data)
+{
+    ssize_t ret = send(fd, data, len, MSG_NOSIGNAL);
+    if (ret == (ssize_t) len) return true;
+
+    if (ret < 0) optics_fail_errno("unable to send announce packet");
+    else optics_fail("unable to send full announce packet: %lu != %ld\n", len, ret);
+
+    return false;
+}
+
+ssize_t socket_recv(int fd, size_t len, void *data)
+{
+    ssize_t ret = recv(fd, data, len, 0);
+    if (ret > 0) return ret;
+
+    optics_fail_errno("unable to send announce packet");
+    return -1;
+}
+
 
 // -----------------------------------------------------------------------------
 // hostname

--- a/src/utils/socket.h
+++ b/src/utils/socket.h
@@ -11,7 +11,11 @@
 // -----------------------------------------------------------------------------
 
 int socket_stream_connect(const char *host, const char *port);
+int socket_stream_listen(const char *port);
+int socket_stream_accept(int fd);
 
+bool socket_send(int fd, size_t len, const void *data);
+ssize_t socket_recv(int fd, size_t len, void *data);
 
 // -----------------------------------------------------------------------------
 // hostname

--- a/test/backend_carbon_test.c
+++ b/test/backend_carbon_test.c
@@ -39,12 +39,12 @@ optics_test_head(external_test)
     if (!test_disconnects) assert_carbon();
 
     struct optics *optics = optics_create(test_name);
-    optics_set_prefix(optics, "optics.tests");
-    optics_set_host(optics, "my.host");
+    optics_set_prefix(optics, "prefix");
 
     struct optics_lens *lens = optics_dist_alloc(optics, "blah");
 
     struct optics_poller *poller = optics_poller_alloc();
+    optics_poller_set_host(poller, "host");
     optics_dump_carbon(poller, "127.0.0.1", "2003");
 
     size_t iterations = test_disconnects ? 10 * 1000 : 100;

--- a/test/backend_carbon_test.c
+++ b/test/backend_carbon_test.c
@@ -5,8 +5,13 @@
 
 #include "test.h"
 
-#include "utils/socket.h"
 #include "utils/time.h"
+#include "utils/socket.h"
+#include "utils/htable.h"
+#include "utils/buffer.h"
+
+#include <unistd.h>
+#include <pthread.h>
 
 
 // -----------------------------------------------------------------------------
@@ -24,12 +29,168 @@ void assert_carbon()
     skip();
 }
 
+struct carbon
+{
+    int listen_fd;
+    pthread_t thread;
+
+    struct buffer buffer;
+};
+
+struct carbon * carbon_start(const char *port);
+void carbon_stop(struct carbon *carbon);
+void carbon_parse(struct carbon *carbon, struct htable *table);
+
+
+// -----------------------------------------------------------------------------
+// internal
+// -----------------------------------------------------------------------------
+
+optics_test_head(backend_carbon_internal_with_source_test)
+{
+    const char *port = "12345";
+    struct carbon *carbon = carbon_start(port);
+
+    struct optics *optics = optics_create(test_name);
+    optics_set_prefix(optics, "prefix");
+    optics_set_source(optics, "source");
+
+    struct optics_lens *counter = optics_counter_alloc(optics, "counter");
+    struct optics_lens *gauge = optics_gauge_alloc(optics, "gauge");
+    struct optics_lens *dist = optics_dist_alloc(optics, "dist");
+
+    struct optics_poller *poller = optics_poller_alloc();
+    optics_poller_set_host(poller, "host");
+    optics_dump_carbon(poller, "127.0.0.1", port);
+
+    for (size_t it = 0; it < 10; ++it) {
+        optics_counter_inc(counter, 1);
+        optics_gauge_set(gauge, 1.0);
+        for (size_t i = 0; i < 100; ++i) optics_dist_record(dist, i);
+
+        if (!optics_poller_poll(poller)) optics_abort();
+
+        // sketchy way to wait for carbon to stop reading our input so we can
+        // read the result without issues.
+        nsleep(1 * 1000 * 1000);
+
+        struct htable result = {0};
+        carbon_parse(carbon, &result);
+        assert_htable_equal(&result, 0,
+                make_kv("prefix.host.source.counter", 1),
+                make_kv("prefix.host.source.gauge", 1),
+                make_kv("prefix.host.source.dist.p50", 50),
+                make_kv("prefix.host.source.dist.p90", 90),
+                make_kv("prefix.host.source.dist.p99", 99),
+                make_kv("prefix.host.source.dist.max", 99),
+                make_kv("prefix.host.source.dist.count", 100));
+
+        htable_reset(&result);
+    }
+
+    optics_poller_free(poller);
+    optics_lens_close(counter);
+    optics_lens_close(gauge);
+    optics_lens_close(dist);
+    optics_close(optics);
+    carbon_stop(carbon);
+}
+optics_test_tail()
+
+
+optics_test_head(backend_carbon_internal_without_source_test)
+{
+    const char *port = "12345";
+    struct carbon *carbon = carbon_start(port);
+
+    struct optics *optics = optics_create(test_name);
+    optics_set_prefix(optics, "prefix");
+
+    struct optics_lens *counter = optics_counter_alloc(optics, "counter");
+    struct optics_lens *gauge = optics_gauge_alloc(optics, "gauge");
+    struct optics_lens *dist = optics_dist_alloc(optics, "dist");
+
+    struct optics_poller *poller = optics_poller_alloc();
+    optics_poller_set_host(poller, "host");
+    optics_dump_carbon(poller, "127.0.0.1", port);
+
+    for (size_t it = 0; it < 10; ++it) {
+        optics_counter_inc(counter, 1);
+        optics_gauge_set(gauge, 1.0);
+        for (size_t i = 0; i < 100; ++i) optics_dist_record(dist, i);
+
+        if (!optics_poller_poll(poller)) optics_abort();
+
+        // sketchy way to wait for carbon to stop reading our input so we can
+        // read the result without issues.
+        nsleep(1 * 1000 * 1000);
+
+        struct htable result = {0};
+        carbon_parse(carbon, &result);
+        assert_htable_equal(&result, 0,
+                make_kv("prefix.host.counter", 1),
+                make_kv("prefix.host.gauge", 1),
+                make_kv("prefix.host.dist.p50", 50),
+                make_kv("prefix.host.dist.p90", 90),
+                make_kv("prefix.host.dist.p99", 99),
+                make_kv("prefix.host.dist.max", 99),
+                make_kv("prefix.host.dist.count", 100));
+
+        htable_reset(&result);
+    }
+
+    optics_poller_free(poller);
+    optics_lens_close(counter);
+    optics_lens_close(gauge);
+    optics_lens_close(dist);
+    optics_close(optics);
+    carbon_stop(carbon);
+}
+optics_test_tail()
+
 
 // -----------------------------------------------------------------------------
 // external
 // -----------------------------------------------------------------------------
 
-optics_test_head(external_test)
+optics_test_head(backend_carbon_external_with_source_test)
+{
+
+    // When turned on the test will take longer so you can have fun starting and
+    // stopping carbon. Leave off by default.
+    enum { test_disconnects = false };
+
+    if (!test_disconnects) assert_carbon();
+
+    struct optics *optics = optics_create(test_name);
+    optics_set_prefix(optics, "prefix");
+    optics_set_source(optics, "source");
+
+    struct optics_lens *lens = optics_dist_alloc(optics, "dist");
+
+    struct optics_poller *poller = optics_poller_alloc();
+    optics_poller_set_host(poller, "host");
+    optics_dump_carbon(poller, "127.0.0.1", "2003");
+
+    size_t iterations = test_disconnects ? 10 * 1000 : 100;
+
+    for (size_t t = 0; t < iterations; ++t) {
+        for (size_t i = 0; i < 10; ++i)
+            optics_dist_record(lens, i);
+
+        if (!optics_poller_poll(poller)) optics_abort();
+
+        if (test_disconnects) nsleep(1000000);
+    }
+
+    optics_poller_free(poller);
+    optics_lens_close(lens);
+    optics_close(optics);
+}
+optics_test_tail()
+
+
+optics_test_head(backend_carbon_external_without_source_test)
 {
 
     // When turned on the test will take longer so you can have fun starting and
@@ -72,8 +233,88 @@ optics_test_tail()
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(external_test),
+        cmocka_unit_test(backend_carbon_internal_with_source_test),
+        cmocka_unit_test(backend_carbon_internal_without_source_test),
+        cmocka_unit_test(backend_carbon_external_with_source_test),
+        cmocka_unit_test(backend_carbon_external_without_source_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+
+// -----------------------------------------------------------------------------
+// carbon
+// -----------------------------------------------------------------------------
+
+void * carbon_run(void *ctx)
+{
+    struct carbon *carbon = ctx;
+
+    int fd = socket_stream_accept(carbon->listen_fd);
+    if (fd < 0) abort();
+
+    ssize_t len;
+    char buffer[8192];
+
+    while ((len = socket_recv(fd, sizeof(buffer), buffer)) >= 0)
+        buffer_write(&carbon->buffer, buffer, len);
+
+    close(fd);
+    return NULL;
+}
+
+void carbon_parse(struct carbon *carbon, struct htable *table)
+{
+    carbon->buffer.data[carbon->buffer.len] = '\0';
+
+    char *saveptr = NULL, *line = NULL;
+    line = strtok_r(carbon->buffer.data, "\n", &saveptr);
+
+    while (line) {
+        char key[optics_name_max_len];
+        double value;
+        optics_ts_t ts;
+        sscanf(line, "%s %lf %lu", key, &value, &ts);
+
+        if (!htable_put(table, key, pun_dtoi(value)).ok) {
+            optics_fail("duplicate key detected '%s'", key);
+            optics_abort();
+        }
+
+        line = strtok_r(NULL, "\n", &saveptr);
+    }
+
+    buffer_reset(&carbon->buffer);
+}
+
+struct carbon * carbon_start(const char *port)
+{
+    struct carbon *carbon = calloc(1, sizeof(*carbon));
+
+    carbon->listen_fd = socket_stream_listen(port);
+    if (carbon->listen_fd < 0) abort();
+
+
+    int err = pthread_create(&carbon->thread, NULL, &carbon_run, carbon);
+    if (err) {
+        optics_fail_ierrno(err, "unable to start carbon thread");
+        optics_abort();
+    }
+
+    return carbon;
+}
+
+void carbon_stop(struct carbon *carbon)
+{
+    close(carbon->listen_fd);
+
+    void *ret = NULL;
+    int err = pthread_join(carbon->thread, &ret);
+    if (err) {
+        optics_fail_ierrno(err, "unable to join carbon thread");
+        optics_abort();
+    }
+
+    free(carbon);
 }

--- a/test/backend_prometheus_test.c
+++ b/test/backend_prometheus_test.c
@@ -11,14 +11,14 @@
 // basics
 // -----------------------------------------------------------------------------
 
-optics_test_head(backend_prometheus_basics_test)
+optics_test_head(backend_prometheus_with_source_test)
 {
     enum { port = 64123 };
     const char *path = "/metrics/prometheus";
 
     struct optics *optics = optics_create(test_name);
-    optics_set_prefix(optics, "optics.tests-1");
-    optics_set_host(optics, "my.host");
+    optics_set_prefix(optics, ".-optics");
+    optics_set_source(optics, ".-source");
 
     struct optics_lens *counter = optics_counter_alloc(optics, "counter");
     struct optics_lens *gauge = optics_gauge_alloc(optics, "gauge");
@@ -26,6 +26,7 @@ optics_test_head(backend_prometheus_basics_test)
 
     struct crest *crest = crest_new();
     struct optics_poller *poller = optics_poller_alloc();
+    optics_poller_set_host(poller, "host");
     optics_dump_prometheus(poller, crest);
     crest_bind(crest, port);
 
@@ -38,15 +39,66 @@ optics_test_head(backend_prometheus_basics_test)
 
         char body[4096];
         snprintf(body, sizeof(body),
-                "# TYPE optics_tests_1_counter counter\n"
-                "optics_tests_1_counter{host=\"my.host\"} %lu\n"
-                "# TYPE optics_tests_1_dist summary\n"
-                "optics_tests_1_dist{host=\"my.host\", quantile=\"0.5\"} 50\n"
-                "optics_tests_1_dist{host=\"my.host\", quantile=\"0.9\"} 90\n"
-                "optics_tests_1_dist{host=\"my.host\", quantile=\"0.99\"} 99\n"
-                "optics_tests_1_dist_count{host=\"my.host\"} %lu\n"
-                "# TYPE optics_tests_1_gauge gauge\n"
-                "optics_tests_1_gauge{host=\"my.host\"} 1\n"
+                "# TYPE __optics_counter counter\n"
+                "__optics_counter{source=\".-source\"} %lu\n"
+                "# TYPE __optics_dist summary\n"
+                "__optics_dist{source=\".-source\",quantile=\"0.5\"} 50\n"
+                "__optics_dist{source=\".-source\",quantile=\"0.9\"} 90\n"
+                "__optics_dist{source=\".-source\",quantile=\"0.99\"} 99\n"
+                "__optics_dist_count{source=\".-source\"} %lu\n"
+                "# TYPE __optics_gauge gauge\n"
+                "__optics_gauge{source=\".-source\"} 1\n"
+                "\n",
+                (it + 1), (it + 1) * 100);
+
+        assert_http_body(port, "GET", path, 200, body);
+    }
+
+    crest_free(crest);
+    optics_poller_free(poller);
+    optics_lens_close(dist);
+    optics_lens_close(gauge);
+    optics_lens_close(counter);
+    optics_close(optics);
+}
+optics_test_tail()
+
+optics_test_head(backend_prometheus_without_source_test)
+{
+    enum { port = 64123 };
+    const char *path = "/metrics/prometheus";
+
+    struct optics *optics = optics_create(test_name);
+    optics_set_prefix(optics, ".-optics");
+
+    struct optics_lens *counter = optics_counter_alloc(optics, "counter");
+    struct optics_lens *gauge = optics_gauge_alloc(optics, "gauge");
+    struct optics_lens *dist = optics_dist_alloc(optics, "dist");
+
+    struct crest *crest = crest_new();
+    struct optics_poller *poller = optics_poller_alloc();
+    optics_poller_set_host(poller, "host");
+    optics_dump_prometheus(poller, crest);
+    crest_bind(crest, port);
+
+    for (size_t it = 0; it < 10; ++it) {
+
+        optics_counter_inc(counter, 1);
+        optics_gauge_set(gauge, 1.0);
+        for (size_t i = 0; i < 100; ++i) optics_dist_record(dist, i);
+        if (!optics_poller_poll(poller)) optics_abort();
+
+        char body[4096];
+        snprintf(body, sizeof(body),
+                "# TYPE __optics_counter counter\n"
+                "__optics_counter %lu\n"
+                "# TYPE __optics_dist summary\n"
+                "__optics_dist{quantile=\"0.5\"} 50\n"
+                "__optics_dist{quantile=\"0.9\"} 90\n"
+                "__optics_dist{quantile=\"0.99\"} 99\n"
+                "__optics_dist_count %lu\n"
+                "# TYPE __optics_gauge gauge\n"
+                "__optics_gauge 1\n"
                 "\n",
                 (it + 1), (it + 1) * 100);
 
@@ -70,7 +122,8 @@ optics_test_tail()
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(backend_prometheus_basics_test),
+        cmocka_unit_test(backend_prometheus_with_source_test),
+        cmocka_unit_test(backend_prometheus_without_source_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/key_test.c
+++ b/test/key_test.c
@@ -26,7 +26,7 @@ optics_test_head(basics_test)
     optics_key_pop(&key, k);
     assert_string_equal(key.data, "blah.bleh");
 
-    k = optics_key_push(&key, "blyh");
+    optics_key_push(&key, "blyh");
     assert_string_equal(key.data, "blah.bleh.blyh");
 
     optics_key_pop(&key, j);


### PR DESCRIPTION
After further reflection it became obvious that there was no need for the host name to be provided by the client library since the daemon will be running on the same host and can therefore easily query that information itself.

Instead of removing it, we found that there are cases where it would be useful to have a per client identifier that will be provided as a label in prometheus. The use case here is if we have multiple instances of a given client on a single host which can all record the same key but should still be differential in the prometheus backend.

As a result we're re-purposing the the host field to hold the source field and we added a new host field in the poller. Note that the source field is optional and if it's not provided then it will not be emitted in any of the backend. This complicated things is various places so I beefed up the carbon tests to make sure keys were being properly created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rattab/optics/9)
<!-- Reviewable:end -->
