### PR TITLE
Fix htable key duplication

### DIFF
--- a/src/utils/htable.c
+++ b/src/utils/htable.c
@@ -120,6 +120,8 @@ struct htable_ret htable_put(struct htable *ht, const char *key, uint64_t value)
     uint64_t hash = hash_key(key);
     htable_resize(ht, probe_window);
 
+    struct htable_bucket *empty = NULL;
+
     for (size_t i = 0; i < probe_window; ++i) {
         struct htable_bucket *bucket = &ht->table[(hash + i) % ht->cap];
 
@@ -128,9 +130,13 @@ struct htable_ret htable_put(struct htable *ht, const char *key, uint64_t value)
             return (struct htable_ret) { .ok = false, .value = bucket->value };
         }
 
+        if (!empty) empty = bucket;
+    }
+
+    if (empty) {
         ht->len++;
-        bucket->key = strndup(key, htable_key_max_len);
-        bucket->value = value;
+        empty->key = strndup(key, htable_key_max_len);
+        empty->value = value;
         return (struct htable_ret) { .ok = true };
     }
 

--- a/test/lens_dist_test.c
+++ b/test/lens_dist_test.c
@@ -58,6 +58,39 @@ optics_test_tail()
 
 
 // -----------------------------------------------------------------------------
+// alloc_get
+// -----------------------------------------------------------------------------
+
+optics_test_head(lens_dist_alloc_get_test)
+{
+    struct optics *optics = optics_create(test_name);
+    const char *lens_name = "blah";
+
+    for (size_t i = 0; i < 3; ++i) {
+        struct optics_lens *l0 = optics_dist_alloc_get(optics, lens_name);
+        if (!l0) optics_abort();
+        for (size_t j = 1; j <= 50; ++j) optics_dist_record(l0, j);
+
+        struct optics_lens *l1 = optics_dist_alloc_get(optics, lens_name);
+        if (!l1) optics_abort();
+        for (size_t j = 1; j <= 50; ++j) optics_dist_record(l0, j + 50);
+
+        optics_epoch_t epoch = optics_epoch_inc(optics);
+
+        struct optics_dist value;
+        optics_dist_read(l0, epoch, &value);
+        assert_dist_equal(value, 100, 50, 90, 99, 100, 0);
+
+        optics_lens_close(l0);
+        optics_lens_free(l1);
+    }
+
+    optics_close(optics);
+}
+optics_test_tail()
+
+
+// -----------------------------------------------------------------------------
 // record/read - exact
 // -----------------------------------------------------------------------------
 

--- a/test/lens_gauge_test.c
+++ b/test/lens_gauge_test.c
@@ -35,6 +35,39 @@ optics_test_tail()
 
 
 // -----------------------------------------------------------------------------
+// alloc_get
+// -----------------------------------------------------------------------------
+
+optics_test_head(lens_gauge_alloc_get_test)
+{
+    struct optics *optics = optics_create(test_name);
+    const char *lens_name = "blah";
+
+    for (size_t i = 0; i < 3; ++i) {
+        struct optics_lens *l0 = optics_gauge_alloc_get(optics, lens_name);
+        if (!l0) optics_abort();
+        optics_gauge_set(l0, 1);
+
+        struct optics_lens *l1 = optics_gauge_alloc_get(optics, lens_name);
+        if (!l1) optics_abort();
+        optics_gauge_set(l1, 2);
+
+        optics_epoch_t epoch = optics_epoch_inc(optics);
+
+        double value;
+        optics_gauge_read(l0, epoch, &value);
+        assert_float_equal(value, 2.0, 0.0);
+
+        optics_lens_close(l0);
+        optics_lens_free(l1);
+    }
+
+    optics_close(optics);
+}
+optics_test_tail()
+
+
+// -----------------------------------------------------------------------------
 // record/read
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Deleting a key in the htable implementation could introduce a hole in the probing window of a later put whose target value is present after the hole. The old implementation did not fully scan the probing window and would instead stop on the first hole and insert the key which could lead to duplicate keys. This PR fixes that issue such that put always scans the full probing window before insert the element.

In production this issue means that a call to `optics_X_alloc` or `optics_X_alloc_get` could create a duplicate metric after a call to `optics_X_free` which could lead to issue in the poller when duplicated metrics are found.

Note that we may want to simplify the probing algorithm using a 2 probe scheme which has better statistical properties and our current scheme always requires that we touch 2-3 cache line anyway. Simpler but requires playing with the hash function which I'd rather leave for another PR.