### PR TITLE
Fix deprecation warning regarding the MHD_USE_EPOLL flag

### DIFF
--- a/src/utils/crest/crest.c
+++ b/src/utils/crest/crest.c
@@ -13,6 +13,9 @@
 #include <stdlib.h>
 #include <limits.h>
 
+#if MHD_VERSION < 0x00095009
+#define MHD_USE_EPOLL MHD_USE_EPOLL_LINUX_ONLY
+#endif
 
 // -----------------------------------------------------------------------------
 // implementation
@@ -71,7 +74,7 @@ bool crest_bind(struct crest *crest, int port)
 {
     int flags = 0;
     flags |= MHD_USE_SELECT_INTERNALLY;
-    flags |= MHD_USE_EPOLL_LINUX_ONLY;
+    flags |= MHD_USE_EPOLL;
 
     crest->mhd_daemon = MHD_start_daemon(
             flags, port, NULL, NULL, microhttpd_cb, crest,


### PR DESCRIPTION
This fixes a deprecation warning regarding the MHD_USE_EPOLL flag on recent versions of microhttpd while maintaining backward compatibility. Since warnings are threated as errors, this change is required to be able to compile.

Version change can be seen here: https://github.com/svn2github/libmicrohttpd/commit/8f6851d96ecc735fde11cad67b27939291c0aa1f#diff-428f639ca6708b2de7935b013127b6caL129