### PR TITLE
Aggregate duplicate metrics

### DIFF
--- a/src/lens_counter.c
+++ b/src/lens_counter.c
@@ -40,7 +40,7 @@ lens_counter_read(struct optics_lens *lens, optics_epoch_t epoch, int64_t *value
     struct lens_counter *counter = lens_sub_ptr(lens->lens, optics_counter);
     if (!counter) return optics_err;
 
-    *value = atomic_exchange_explicit(&counter->value[epoch], 0, memory_order_relaxed);
+    *value += atomic_exchange_explicit(&counter->value[epoch], 0, memory_order_relaxed);
     return optics_ok;
 }
 

--- a/src/lens_dist.c
+++ b/src/lens_dist.c
@@ -97,7 +97,7 @@ lens_dist_read(struct optics_lens *lens, optics_epoch_t epoch, struct optics_dis
         // with straglers which can be dealt with by the poller.
         if (slock_is_locked(&dist->lock)) return optics_busy;
 
-        value->n = dist->n;
+        value->n += dist->n;
         dist->n = 0;
 
         value->max = dist->max;
@@ -110,6 +110,8 @@ lens_dist_read(struct optics_lens *lens, optics_epoch_t epoch, struct optics_dis
 
         slock_unlock(&dist->lock);
     }
+
+    assert(false && "merging logic missing");
 
     if (entries > 0) {
         qsort(reservoir, entries, sizeof(double), lens_dist_value_cmp);

--- a/src/lens_gauge.c
+++ b/src/lens_gauge.c
@@ -53,6 +53,11 @@ lens_gauge_read(struct optics_lens *lens, optics_epoch_t epoch, double *value)
     if (!gauge) return optics_err;
 
     uint64_t result = atomic_load_explicit(&gauge->value, memory_order_relaxed);
+
+    // Last writer wins would be semantically consistent but complicates things
+    // too much: would require that we have the timestamp of both writes which
+    // in turns require that we record the timestamp of each writes which is
+    // just not worth the effort.
     *value = pun_itod(result);
 
     return optics_ok;

--- a/src/lens_histo.c
+++ b/src/lens_histo.c
@@ -108,14 +108,22 @@ lens_histo_read(struct optics_lens *lens, optics_epoch_t epoch, struct optics_hi
     struct lens_histo *histo = lens_sub_ptr(lens->lens, optics_histo);
     if (!histo) return optics_err;
 
-    value->buckets_len = histo->buckets_len;
-    memcpy(value->buckets, histo->buckets, histo->buckets_len * sizeof(histo->buckets[0]));
+    if (!value->buckets_len) {
+        value->buckets_len = histo->buckets_len;
+        memcpy(value->buckets, histo->buckets, histo->buckets_len * sizeof(histo->buckets[0]));
+    }
+    else {
+        if (value->buckets_len != histo->buckets_len) return optics_err;
+        for (size_t i = 0; i < value->buckets_len; ++i) {
+            if (value->buckets[i] != histo->buckets[i]) return optics_err;
+        }
+    }
 
     struct lens_histo_epoch *counters = &histo->epochs[epoch];
-    value->below = atomic_exchange_explicit(&counters->below, 0, memory_order_relaxed);
-    value->above = atomic_exchange_explicit(&counters->above, 0, memory_order_relaxed);
+    value->below += atomic_exchange_explicit(&counters->below, 0, memory_order_relaxed);
+    value->above += atomic_exchange_explicit(&counters->above, 0, memory_order_relaxed);
     for (size_t i = 0; i < histo->buckets_len - 1; ++i) {
-        value->counts[i] =
+        value->counts[i] +=
             atomic_exchange_explicit(&counters->counts[i], 0, memory_order_relaxed);
     }
 

--- a/src/optics.h
+++ b/src/optics.h
@@ -197,7 +197,7 @@ struct optics_poll
     const char *host;
     const char *prefix;
     const char *source;
-    struct optics_key *key;
+    struct optics_key key;
 
     enum optics_lens_type type;
     union optics_poll_value value;

--- a/src/poller_poll.c
+++ b/src/poller_poll.c
@@ -31,6 +31,7 @@ struct poller_list
 struct poller_poll_ctx
 {
     struct optics_poller *poller;
+    struct htable *lenses;
     optics_epoch_t epoch;
 
     const char *prefix;
@@ -52,34 +53,43 @@ static enum optics_ret poller_poll_lens(void *ctx_, struct optics_lens *lens)
     struct poller_poll_ctx *ctx = ctx_;
 
     size_t old_key = optics_key_push(ctx->key, optics_lens_name(lens));
+    struct htable_ret ret = htable_get(&ctx->lenses, ctx->key.data);
 
-    struct optics_poll poll = {
-        .host = optics_poller_get_host(ctx->poller),
-        .prefix = ctx->prefix,
-        .source = ctx->source,
-        .key = ctx->key,
-        .type = optics_lens_type(lens),
-        .ts = ctx->ts,
-        .elapsed = ctx->elapsed
-    };
+    struct optics_poll * poll = NULL;
+    if (ret.ok) poll = pun_itop(ret.value);
+    else {
+        poll = malloc(sizeof(*poll));
+        *poll = (struct optics_poll) {
+            .host = optics_poller_get_host(ctx->poller),
+            .prefix = ctx->prefix,
+            .source = ctx->source,
+            .key = ctx->key,
+            .type = optics_lens_type(lens),
+            .ts = ctx->ts,
+            .elapsed = ctx->elapsed,
+        }
+
+        ret = htable_put(&ctx->lenses, ctx->key.data);
+        optics_assert(ret.ok, "unable to insert into htable: '%s'", ctx->key.data);
+    }
 
     enum optics_ret ret;
 
-    switch (poll.type) {
+    switch (poll->type) {
     case optics_counter:
-        ret = optics_counter_read(lens, ctx->epoch, &poll.value.counter);
+        ret = optics_counter_read(lens, ctx->epoch, &poll->value.counter);
         break;
 
     case optics_gauge:
-        ret = optics_gauge_read(lens, ctx->epoch, &poll.value.gauge);
+        ret = optics_gauge_read(lens, ctx->epoch, &poll->value.gauge);
         break;
 
     case optics_dist:
-        ret = optics_dist_read(lens, ctx->epoch, &poll.value.dist);
+        ret = optics_dist_read(lens, ctx->epoch, &poll->value.dist);
         break;
 
     case optics_histo:
-        ret = optics_histo_read(lens, ctx->epoch, &poll.value.histo);
+        ret = optics_histo_read(lens, ctx->epoch, &poll->value.histo);
         break;
 
     default:
@@ -88,11 +98,7 @@ static enum optics_ret poller_poll_lens(void *ctx_, struct optics_lens *lens)
         break;
     }
 
-
-    if (ret == optics_ok)
-        poller_backend_record(ctx->poller, optics_poll_metric, &poll);
-
-    else if (ret == optics_busy)
+    if (ret == optics_busy)
         optics_warn("skipping lens '%s'", ctx->key->data);
 
     else if (ret == optics_err)
@@ -108,15 +114,22 @@ static enum optics_ret poller_poll_lens(void *ctx_, struct optics_lens *lens)
 // -----------------------------------------------------------------------------
 
 static void poller_poll_optics(
-        struct optics_poller *poller, struct poller_list_item *item, optics_ts_t ts)
+        struct optics_poller *poller,
+        struct poller_list_item *item,
+        struct htable *lenses,
+        optics_ts_t ts)
 {
     struct optics_key key = {0};
+    optics_key_push(&key, prefix);
+    optics_key_push(&key, source);
+
     struct poller_poll_ctx ctx = {
         .poller = poller,
+        .lenses = lenses,
         .epoch = item->epoch,
         .prefix = optics_get_prefix(item->optics),
         .source = optics_get_source(item->optics),
-        .key = &key,
+        .key = &key;
         .ts = ts,
     };
 
@@ -151,6 +164,23 @@ static enum shm_ret poller_shm_cb(void *ctx, const char *name)
     return shm_ok;
 }
 
+static void poller_dump(struct optics_poller *poller, struct htable *lenses)
+{
+    poller_backend_record(poller, optics_poll_begin, NULL);
+
+    struct htable_bucket * bucket = htable_next(&lenses, NULL);
+    for (; bucket; bucket = htable_next(&lenses, bucket)) {
+        struct optics_poll * item = pun_itop(bucket->value);
+
+        poller_backend_record(Poller, optics_poll_metric, item);
+        free(poll);
+    }
+
+    poller_backend_record(poller, optics_poll_done, NULL);
+
+    htable_reset(&lenses);
+}
+
 bool optics_poller_poll(struct optics_poller *poller)
 {
     return optics_poller_poll_at(poller, clock_wall());
@@ -172,12 +202,13 @@ bool optics_poller_poll_at(struct optics_poller *poller, optics_ts_t ts)
     // just wait a bit and deal with stragglers if we run into them.
     nsleep(1 * 1000 * 1000);
 
-    poller_backend_record(poller, optics_poll_begin, NULL);
+    struct htable lenses = {0};
+    htable_reset(&lenses);
 
     for (size_t i = 0; i < to_poll.len; ++i)
-        poller_poll_optics(poller, &to_poll.items[i], ts);
+        poller_poll_optics(poller, &lenses, &to_poll.items[i], ts);
 
-    poller_backend_record(poller, optics_poll_done, NULL);
+    poller_dump(poller, &lenses);
 
     for (size_t i = 0; i < to_poll.len; ++i)
        optics_close(to_poll.items[i].optics);


### PR DESCRIPTION
Turns out this is a bad idea and this branch is kept as reminder to future-self to stop trying to do this. There's a practical and a deeper conceptual problem.

On the practical side, the issue relies on how to aggregate metrics that have different elapsed times. While it might be tempting to sum up the elapsed times and the values and then let the normalization helpers take care of the rest. That would be wrong as it would calculate an average. As an example, if we had a metric with a count of 10 for 1 second and a metric with a count of 20 for 2 seconds, the expected result should be 20 and not 10 which is the average.

To get the correct result, we'd first need to normalize the values and sum up the resulting rates. That completely fucks up the prometheus backend which doesn't want to use normalized rates. So then we'd need to keep both the normalized and the aggregate rates and then everything gets weird and complicated. This issue then leads us to pick a side between rate or absolute output which would be a good overall thing for the library.

From a conceptual level things get a bit trickier, is it really a good idea to aggregate in the poller? It seems like it's just a better idea to send the fine-grained metrics and have the consumer do the aggregations themselves. There's two issues with that:

- Distributions can only be aggregated without introducing too much bias in the poller as it has the raw values. While there are alternatives like using the max on 90th percentiles, it's a pretty sketchy solution that doesn't properly represent the data. Note that a degree of bias will always be present as we sample the values when recording.

- We end up creating a shit ton metrics. A common use case of having a per-cpu optics instances to avoid contention on recorded metrics can easily increase the number of recorded metrics by a factor of 40 on beefy servers. While it should be the responsibility of the storage engine to not suck, popular storage backends like whisper would just melt under the load.

So the more I write about this the less I'm sure in which direction to go. For now, I'll just stick to the `source` solution that segregating the metrics in their key-space and doing the aggregation on the display side. More scalable alternatives to whisper are becoming increasingly common so the storage requirement are less of an issue. Would still be nice to have a better story for distribution aggregation though.