### PR TITLE
Rework headers for erlang nif interface

### DIFF
--- a/src/optics.c
+++ b/src/optics.c
@@ -55,11 +55,7 @@ static const uint64_t version = 2;
 // impl
 // -----------------------------------------------------------------------------
 
-struct optics_lens
-{
-    struct optics *optics;
-    struct lens *lens;
-};
+
 
 static void * optics_ptr(struct optics *optics, optics_off_t off, size_t len);
 static optics_off_t optics_alloc(struct optics *optics, size_t len);

--- a/src/optics.h
+++ b/src/optics.h
@@ -78,11 +78,25 @@ const char *optics_get_prefix(struct optics *);
 bool optics_set_prefix(struct optics *, const char *prefix);
 
 
+
+
+// -----------------------------------------------------------------------------
+// epoch
+// -----------------------------------------------------------------------------
+
+typedef size_t optics_epoch_t;
+optics_epoch_t optics_epoch(struct optics *optics);
+
+
 // -----------------------------------------------------------------------------
 // lens
 // -----------------------------------------------------------------------------
 
-struct optics_lens;
+struct optics_lens
+{
+    struct optics *optics;
+    struct lens *lens;
+};
 
 enum optics_lens_type
 {
@@ -110,10 +124,16 @@ bool optics_lens_free(struct optics_lens *);
 struct optics_lens * optics_counter_alloc(struct optics *, const char *name);
 struct optics_lens * optics_counter_alloc_get(struct optics *, const char *name);
 bool optics_counter_inc(struct optics_lens *, int64_t value);
+enum optics_ret
+  optics_counter_read(struct optics_lens *lens, optics_epoch_t epoch, int64_t *value);
+
 
 struct optics_lens * optics_gauge_alloc(struct optics *, const char *name);
 struct optics_lens * optics_gauge_alloc_get(struct optics *, const char *name);
 bool optics_gauge_set(struct optics_lens *, double value);
+enum optics_ret
+    optics_gauge_read(struct optics_lens *lens, optics_epoch_t epoch, double *value);
+
 
 struct optics_dist
 {
@@ -128,6 +148,8 @@ struct optics_dist
 struct optics_lens * optics_dist_alloc(struct optics *, const char *name);
 struct optics_lens * optics_dist_alloc_get(struct optics *, const char *name);
 bool optics_dist_record(struct optics_lens *, double value);
+enum optics_ret
+    optics_dist_read(struct optics_lens *lens, optics_epoch_t epoch, struct optics_dist *value);
 
 struct optics_histo
 {
@@ -143,6 +165,8 @@ struct optics_lens * optics_histo_alloc(
 struct optics_lens * optics_histo_alloc_get(
         struct optics *, const char *name, const double *buckets, size_t buckets_len);
 bool optics_histo_inc(struct optics_lens *, double value);
+enum optics_ret
+    optics_histo_read(struct optics_lens *lens, optics_epoch_t epoch, struct optics_histo *value);
 
 struct optics_quantile
 {
@@ -157,6 +181,9 @@ struct optics_lens * optics_quantile_alloc(
 struct optics_lens * optics_quantile_alloc_get(
     struct optics *, const char *name, double quantile, double estimate, double adjustment_value);
 bool optics_quantile_update(struct optics_lens *, double value);
+enum optics_ret optics_quantile_read(
+        struct optics_lens *lens, optics_epoch_t epoch, struct optics_quantile *value);
+
 
 
 // -----------------------------------------------------------------------------
@@ -293,3 +320,4 @@ struct crest;
 void optics_dump_stdout(struct optics_poller *);
 void optics_dump_carbon(struct optics_poller *, const char *host, const char *port);
 void optics_dump_rest(struct optics_poller *poller, struct crest *crest);
+

--- a/src/optics_priv.h
+++ b/src/optics_priv.h
@@ -12,8 +12,6 @@
 // epoch
 // -----------------------------------------------------------------------------
 
-typedef size_t optics_epoch_t;
-optics_epoch_t optics_epoch(struct optics *optics);
 optics_epoch_t optics_epoch_inc(struct optics *optics);
 optics_epoch_t optics_epoch_inc_at(
         struct optics *optics, optics_ts_t now, optics_ts_t *last_inc);


### PR DESCRIPTION
Moved the _read function definitions from optics.c to optics.h, and the type definion of optics_epoch
to allow the building of erl-optics.