### PR TITLE
Add compile check for assert_float_equal to avoid macro collision

### DIFF
--- a/test/test.h
+++ b/test/test.h
@@ -48,9 +48,10 @@ void assert_mt();
 
 bool assert_float_equal_impl(double a, double b, double epsilon);
 
+#ifndef assert_float_equal
 #define assert_float_equal(a, b, epsilon)                       \
     assert_true(assert_float_equal_impl(a, b, epsilon))
-
+#endif
 
 bool assert_htable_equal_impl(
         struct htable *,


### PR DESCRIPTION
Some versions of `cmocka` provide a definition of the macro, this avoids collisions.