### PR TITLE
Change adjustment type from size_t to double

### DIFF
--- a/src/lens_quantile.c
+++ b/src/lens_quantile.c
@@ -48,7 +48,7 @@ lens_quantile_alloc(
 
 static double calculate_quantile(struct lens_quantile *quantile)
 {
-    size_t adjustment =
+    double adjustment =
         atomic_load_explicit(&quantile->multiplier, memory_order_relaxed) *
         quantile->adjustment_value;
 


### PR DESCRIPTION
This changes the type of the adjustment value to fix a bug where sometimes giving values under the expected quantile would overflow into astronomical numbers.